### PR TITLE
incorporate IsSet on all types

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -13,31 +13,39 @@ import (
 type Bool struct {
 	Bool  bool
 	Valid bool
+	set   bool
 }
 
 // NewBool creates a new Bool
-func NewBool(b bool, valid bool) Bool {
+func NewBool(b bool, valid, set bool) Bool {
 	return Bool{
 		Bool:  b,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // BoolFrom creates a new Bool that will always be valid.
 func BoolFrom(b bool) Bool {
-	return NewBool(b, true)
+	return NewBool(b, true, true)
 }
 
 // BoolFromPtr creates a new Bool that will be null if f is nil.
 func BoolFromPtr(b *bool) Bool {
 	if b == nil {
-		return NewBool(false, false)
+		return NewBool(false, false, true)
 	}
-	return NewBool(*b, true)
+	return NewBool(*b, true, true)
+}
+
+func (b Bool) IsSet() bool {
+	return b.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Bool) UnmarshalJSON(data []byte) error {
+	b.set = true
+
 	if bytes.Equal(data, NullBytes) {
 		b.Bool = false
 		b.Valid = false

--- a/bool_test.go
+++ b/bool_test.go
@@ -40,6 +40,9 @@ func TestUnmarshalBool(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullBool(t, null, "null json")
+	if !null.set {
+		t.Error("should be set", err)
+	}
 
 	var badType Bool
 	err = json.Unmarshal(intJSON, &badType)
@@ -85,13 +88,13 @@ func TestMarshalBool(t *testing.T) {
 	maybePanic(err)
 	assertJSONEquals(t, data, "true", "non-empty json marshal")
 
-	zero := NewBool(false, true)
+	zero := NewBool(false, true, true)
 	data, err = json.Marshal(zero)
 	maybePanic(err)
 	assertJSONEquals(t, data, "false", "zero json marshal")
 
 	// invalid values should be encoded as null
-	null := NewBool(false, false)
+	null := NewBool(false, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -103,13 +106,13 @@ func TestMarshalBoolText(t *testing.T) {
 	maybePanic(err)
 	assertJSONEquals(t, data, "true", "non-empty text marshal")
 
-	zero := NewBool(false, true)
+	zero := NewBool(false, true, true)
 	data, err = zero.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "false", "zero text marshal")
 
 	// invalid values should be encoded as null
-	null := NewBool(false, false)
+	null := NewBool(false, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -122,7 +125,7 @@ func TestBoolPointer(t *testing.T) {
 		t.Errorf("bad %s bool: %#v ≠ %v\n", "pointer", ptr, true)
 	}
 
-	null := NewBool(false, false)
+	null := NewBool(false, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s bool: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -135,19 +138,19 @@ func TestBoolIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewBool(false, false)
+	null := NewBool(false, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewBool(false, true)
+	zero := NewBool(false, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestBoolSetValid(t *testing.T) {
-	change := NewBool(false, false)
+	change := NewBool(false, false, true)
 	assertNullBool(t, change, "SetValid()")
 	change.SetValid(true)
 	assertBool(t, change, "SetValid()")

--- a/byte.go
+++ b/byte.go
@@ -11,31 +11,39 @@ import (
 type Byte struct {
 	Byte  byte
 	Valid bool
+	set   bool
 }
 
 // NewByte creates a new Byte
-func NewByte(b byte, valid bool) Byte {
+func NewByte(b byte, valid, set bool) Byte {
 	return Byte{
 		Byte:  b,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // ByteFrom creates a new Byte that will always be valid.
 func ByteFrom(b byte) Byte {
-	return NewByte(b, true)
+	return NewByte(b, true, true)
 }
 
 // ByteFromPtr creates a new Byte that be null if i is nil.
 func ByteFromPtr(b *byte) Byte {
 	if b == nil {
-		return NewByte(0, false)
+		return NewByte(0, false, true)
 	}
-	return NewByte(*b, true)
+	return NewByte(*b, true, true)
+}
+
+func (b Byte) IsSet() bool {
+	return b.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Byte) UnmarshalJSON(data []byte) error {
+	b.set = true
+
 	if len(data) == 0 || bytes.Equal(data, NullBytes) {
 		b.Valid = false
 		b.Byte = 0

--- a/byte_test.go
+++ b/byte_test.go
@@ -34,6 +34,9 @@ func TestUnmarshalByte(t *testing.T) {
 	err := json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullByte(t, null, "null json")
+	if !null.set {
+		t.Error("expected set to be true")
+	}
 
 	var badType Byte
 	err = json.Unmarshal(boolJSON, &badType)
@@ -77,7 +80,7 @@ func TestMarshalByte(t *testing.T) {
 	assertJSONEquals(t, data, `"b"`, "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewByte(0, false)
+	null := NewByte(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -90,7 +93,7 @@ func TestMarshalByteText(t *testing.T) {
 	assertJSONEquals(t, data, "b", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewByte(0, false)
+	null := NewByte(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -103,7 +106,7 @@ func TestBytePointer(t *testing.T) {
 		t.Errorf("bad %s int: %#v ≠ %d\n", "pointer", ptr, 'b')
 	}
 
-	null := NewByte(0, false)
+	null := NewByte(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -116,19 +119,19 @@ func TestByteIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewByte(0, false)
+	null := NewByte(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewByte(0, true)
+	zero := NewByte(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestByteSetValid(t *testing.T) {
-	change := NewByte(0, false)
+	change := NewByte(0, false, true)
 	assertNullByte(t, change, "SetValid()")
 	change.SetValid('b')
 	assertByte(t, change, "SetValid()")

--- a/bytes.go
+++ b/bytes.go
@@ -15,32 +15,40 @@ var NullBytes = []byte("null")
 type Bytes struct {
 	Bytes []byte
 	Valid bool
+	set   bool
 }
 
 // NewBytes creates a new Bytes
-func NewBytes(b []byte, valid bool) Bytes {
+func NewBytes(b []byte, valid, set bool) Bytes {
 	return Bytes{
 		Bytes: b,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // BytesFrom creates a new Bytes that will be invalid if nil.
 func BytesFrom(b []byte) Bytes {
-	return NewBytes(b, b != nil)
+	return NewBytes(b, b != nil, true)
 }
 
 // BytesFromPtr creates a new Bytes that will be invalid if nil.
 func BytesFromPtr(b *[]byte) Bytes {
 	if b == nil {
-		return NewBytes(nil, false)
+		return NewBytes(nil, false, true)
 	}
-	n := NewBytes(*b, true)
+	n := NewBytes(*b, true, true)
 	return n
+}
+
+func (b Bytes) IsSet() bool {
+	return b.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (b *Bytes) UnmarshalJSON(data []byte) error {
+	b.set = true
+
 	if bytes.Equal(data, NullBytes) {
 		b.Valid = false
 		b.Bytes = nil

--- a/float32.go
+++ b/float32.go
@@ -13,31 +13,38 @@ import (
 type Float32 struct {
 	Float32 float32
 	Valid   bool
+	set     bool
 }
 
 // NewFloat32 creates a new Float32
-func NewFloat32(f float32, valid bool) Float32 {
+func NewFloat32(f float32, valid, set bool) Float32 {
 	return Float32{
 		Float32: f,
 		Valid:   valid,
+		set:     set,
 	}
 }
 
 // Float32From creates a new Float32 that will always be valid.
 func Float32From(f float32) Float32 {
-	return NewFloat32(f, true)
+	return NewFloat32(f, true, true)
 }
 
 // Float32FromPtr creates a new Float32 that be null if f is nil.
 func Float32FromPtr(f *float32) Float32 {
 	if f == nil {
-		return NewFloat32(0, false)
+		return NewFloat32(0, false, true)
 	}
-	return NewFloat32(*f, true)
+	return NewFloat32(*f, true, true)
+}
+
+func (f Float32) IsSet() bool {
+	return f.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (f *Float32) UnmarshalJSON(data []byte) error {
+	f.set = true
 	if bytes.Equal(data, NullBytes) {
 		f.Valid = false
 		f.Float32 = 0

--- a/float32_test.go
+++ b/float32_test.go
@@ -39,6 +39,9 @@ func TestUnmarshalFloat32(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullFloat32(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Float32
 	err = json.Unmarshal(boolJSON, &badType)
@@ -73,7 +76,7 @@ func TestMarshalFloat32(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat32(0, false)
+	null := NewFloat32(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -86,7 +89,7 @@ func TestMarshalFloat32Text(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat32(0, false)
+	null := NewFloat32(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -99,7 +102,7 @@ func TestFloat32Pointer(t *testing.T) {
 		t.Errorf("bad %s float32: %#v ≠ %v\n", "pointer", ptr, 1.2345)
 	}
 
-	null := NewFloat32(0, false)
+	null := NewFloat32(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s float32: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -112,19 +115,19 @@ func TestFloat32IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewFloat32(0, false)
+	null := NewFloat32(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewFloat32(0, true)
+	zero := NewFloat32(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestFloat32SetValid(t *testing.T) {
-	change := NewFloat32(0, false)
+	change := NewFloat32(0, false, true)
 	assertNullFloat32(t, change, "SetValid()")
 	change.SetValid(1.2345)
 	assertFloat32(t, change, "SetValid()")

--- a/float64.go
+++ b/float64.go
@@ -13,31 +13,38 @@ import (
 type Float64 struct {
 	Float64 float64
 	Valid   bool
+	set     bool
 }
 
 // NewFloat64 creates a new Float64
-func NewFloat64(f float64, valid bool) Float64 {
+func NewFloat64(f float64, valid, set bool) Float64 {
 	return Float64{
 		Float64: f,
 		Valid:   valid,
+		set:     set,
 	}
 }
 
 // Float64From creates a new Float64 that will always be valid.
 func Float64From(f float64) Float64 {
-	return NewFloat64(f, true)
+	return NewFloat64(f, true, true)
 }
 
 // Float64FromPtr creates a new Float64 that be null if f is nil.
 func Float64FromPtr(f *float64) Float64 {
 	if f == nil {
-		return NewFloat64(0, false)
+		return NewFloat64(0, false, true)
 	}
-	return NewFloat64(*f, true)
+	return NewFloat64(*f, true, true)
+}
+
+func (f Float64) IsSet() bool {
+	return f.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (f *Float64) UnmarshalJSON(data []byte) error {
+	f.set = true
 	if bytes.Equal(data, NullBytes) {
 		f.Float64 = 0
 		f.Valid = false

--- a/float64_test.go
+++ b/float64_test.go
@@ -39,6 +39,9 @@ func TestUnmarshalFloat64(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullFloat64(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Float64
 	err = json.Unmarshal(boolJSON, &badType)
@@ -73,7 +76,7 @@ func TestMarshalFloat64(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat64(0, false)
+	null := NewFloat64(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -86,7 +89,7 @@ func TestMarshalFloat64Text(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat64(0, false)
+	null := NewFloat64(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -99,7 +102,7 @@ func TestFloat64Pointer(t *testing.T) {
 		t.Errorf("bad %s float64: %#v ≠ %v\n", "pointer", ptr, 1.2345)
 	}
 
-	null := NewFloat64(0, false)
+	null := NewFloat64(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s float64: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -112,19 +115,19 @@ func TestFloat64IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewFloat64(0, false)
+	null := NewFloat64(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewFloat64(0, true)
+	zero := NewFloat64(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestFloat64SetValid(t *testing.T) {
-	change := NewFloat64(0, false)
+	change := NewFloat64(0, false, true)
 	assertNullFloat64(t, change, "SetValid()")
 	change.SetValid(1.2345)
 	assertFloat64(t, change, "SetValid()")

--- a/int.go
+++ b/int.go
@@ -14,31 +14,39 @@ import (
 type Int struct {
 	Int   int
 	Valid bool
+	set   bool
 }
 
 // NewInt creates a new Int
-func NewInt(i int, valid bool) Int {
+func NewInt(i int, valid, set bool) Int {
 	return Int{
 		Int:   i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // IntFrom creates a new Int that will always be valid.
 func IntFrom(i int) Int {
-	return NewInt(i, true)
+	return NewInt(i, true, true)
 }
 
 // IntFromPtr creates a new Int that be null if i is nil.
 func IntFromPtr(i *int) Int {
 	if i == nil {
-		return NewInt(0, false)
+		return NewInt(0, false, true)
 	}
-	return NewInt(*i, true)
+	return NewInt(*i, true, true)
+}
+
+func (i Int) IsSet() bool {
+	return i.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int) UnmarshalJSON(data []byte) error {
+	i.set = true
+
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int = 0

--- a/int16.go
+++ b/int16.go
@@ -15,31 +15,38 @@ import (
 type Int16 struct {
 	Int16 int16
 	Valid bool
+	set   bool
 }
 
 // NewInt16 creates a new Int16
-func NewInt16(i int16, valid bool) Int16 {
+func NewInt16(i int16, valid, set bool) Int16 {
 	return Int16{
 		Int16: i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // Int16From creates a new Int16 that will always be valid.
 func Int16From(i int16) Int16 {
-	return NewInt16(i, true)
+	return NewInt16(i, true, true)
 }
 
 // Int16FromPtr creates a new Int16 that be null if i is nil.
 func Int16FromPtr(i *int16) Int16 {
 	if i == nil {
-		return NewInt16(0, false)
+		return NewInt16(0, false, true)
 	}
-	return NewInt16(*i, true)
+	return NewInt16(*i, true, true)
+}
+
+func (i Int16) IsSet() bool {
+	return i.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int16) UnmarshalJSON(data []byte) error {
+	i.set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int16 = 0

--- a/int16_test.go
+++ b/int16_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalInt16(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt16(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Int16
 	err = json.Unmarshal(boolJSON, &badType)
@@ -99,7 +102,7 @@ func TestMarshalInt16(t *testing.T) {
 	assertJSONEquals(t, data, "32766", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt16(0, false)
+	null := NewInt16(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -112,7 +115,7 @@ func TestMarshalInt16Text(t *testing.T) {
 	assertJSONEquals(t, data, "32766", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt16(0, false)
+	null := NewInt16(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -125,7 +128,7 @@ func TestInt16Pointer(t *testing.T) {
 		t.Errorf("bad %s int16: %#v ≠ %d\n", "pointer", ptr, 32766)
 	}
 
-	null := NewInt16(0, false)
+	null := NewInt16(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int16: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -138,19 +141,19 @@ func TestInt16IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt16(0, false)
+	null := NewInt16(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt16(0, true)
+	zero := NewInt16(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt16SetValid(t *testing.T) {
-	change := NewInt16(0, false)
+	change := NewInt16(0, false, true)
 	assertNullInt16(t, change, "SetValid()")
 	change.SetValid(32766)
 	assertInt16(t, change, "SetValid()")

--- a/int32.go
+++ b/int32.go
@@ -16,31 +16,38 @@ import (
 type Int32 struct {
 	Int32 int32
 	Valid bool
+	set   bool
 }
 
 // NewInt32 creates a new Int32
-func NewInt32(i int32, valid bool) Int32 {
+func NewInt32(i int32, valid, set bool) Int32 {
 	return Int32{
 		Int32: i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // Int32From creates a new Int32 that will always be valid.
 func Int32From(i int32) Int32 {
-	return NewInt32(i, true)
+	return NewInt32(i, true, true)
 }
 
 // Int32FromPtr creates a new Int32 that be null if i is nil.
 func Int32FromPtr(i *int32) Int32 {
 	if i == nil {
-		return NewInt32(0, false)
+		return NewInt32(0, false, true)
 	}
-	return NewInt32(*i, true)
+	return NewInt32(*i, true, true)
+}
+
+func (i Int32) IsSet() bool {
+	return i.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int32) UnmarshalJSON(data []byte) error {
+	i.set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int32 = 0

--- a/int32_test.go
+++ b/int32_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalInt32(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt32(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Int32
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalInt32(t *testing.T) {
 	assertJSONEquals(t, data, "2147483646", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt32(0, false)
+	null := NewInt32(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalInt32Text(t *testing.T) {
 	assertJSONEquals(t, data, "2147483646", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt32(0, false)
+	null := NewInt32(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestInt32Pointer(t *testing.T) {
 		t.Errorf("bad %s int32: %#v ≠ %d\n", "pointer", ptr, 2147483646)
 	}
 
-	null := NewInt32(0, false)
+	null := NewInt32(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int32: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestInt32IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt32(0, false)
+	null := NewInt32(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt32(0, true)
+	zero := NewInt32(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt32SetValid(t *testing.T) {
-	change := NewInt32(0, false)
+	change := NewInt32(0, false, true)
 	assertNullInt32(t, change, "SetValid()")
 	change.SetValid(2147483646)
 	assertInt32(t, change, "SetValid()")

--- a/int64.go
+++ b/int64.go
@@ -13,31 +13,38 @@ import (
 type Int64 struct {
 	Int64 int64
 	Valid bool
+	set   bool
 }
 
 // NewInt64 creates a new Int64
-func NewInt64(i int64, valid bool) Int64 {
+func NewInt64(i int64, valid, set bool) Int64 {
 	return Int64{
 		Int64: i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // Int64From creates a new Int64 that will always be valid.
 func Int64From(i int64) Int64 {
-	return NewInt64(i, true)
+	return NewInt64(i, true, true)
 }
 
 // Int64FromPtr creates a new Int64 that be null if i is nil.
 func Int64FromPtr(i *int64) Int64 {
 	if i == nil {
-		return NewInt64(0, false)
+		return NewInt64(0, false, true)
 	}
-	return NewInt64(*i, true)
+	return NewInt64(*i, true, true)
+}
+
+func (i Int64) IsSet() bool {
+	return i.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int64) UnmarshalJSON(data []byte) error {
+	i.set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int64 = 0

--- a/int64_test.go
+++ b/int64_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalInt64(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt64(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Int64
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalInt64(t *testing.T) {
 	assertJSONEquals(t, data, "9223372036854775806", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt64(0, false)
+	null := NewInt64(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalInt64Text(t *testing.T) {
 	assertJSONEquals(t, data, "9223372036854775806", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt64(0, false)
+	null := NewInt64(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestInt64Pointer(t *testing.T) {
 		t.Errorf("bad %s int64: %#v ≠ %d\n", "pointer", ptr, 9223372036854775806)
 	}
 
-	null := NewInt64(0, false)
+	null := NewInt64(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int64: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestInt64IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt64(0, false)
+	null := NewInt64(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt64(0, true)
+	zero := NewInt64(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt64SetValid(t *testing.T) {
-	change := NewInt64(0, false)
+	change := NewInt64(0, false, true)
 	assertNullInt64(t, change, "SetValid()")
 	change.SetValid(9223372036854775806)
 	assertInt64(t, change, "SetValid()")

--- a/int8.go
+++ b/int8.go
@@ -15,31 +15,38 @@ import (
 type Int8 struct {
 	Int8  int8
 	Valid bool
+	set   bool
 }
 
 // NewInt8 creates a new Int8
-func NewInt8(i int8, valid bool) Int8 {
+func NewInt8(i int8, valid, set bool) Int8 {
 	return Int8{
 		Int8:  i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // Int8From creates a new Int8 that will always be valid.
 func Int8From(i int8) Int8 {
-	return NewInt8(i, true)
+	return NewInt8(i, true, true)
 }
 
 // Int8FromPtr creates a new Int8 that be null if i is nil.
 func Int8FromPtr(i *int8) Int8 {
 	if i == nil {
-		return NewInt8(0, false)
+		return NewInt8(0, false, true)
 	}
-	return NewInt8(*i, true)
+	return NewInt8(*i, true, true)
+}
+
+func (i Int8) IsSet() bool {
+	return i.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (i *Int8) UnmarshalJSON(data []byte) error {
+	i.set = true
 	if bytes.Equal(data, NullBytes) {
 		i.Valid = false
 		i.Int8 = 0

--- a/int8_test.go
+++ b/int8_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalInt8(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt8(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Int8
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalInt8(t *testing.T) {
 	assertJSONEquals(t, data, "126", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt8(0, false)
+	null := NewInt8(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalInt8Text(t *testing.T) {
 	assertJSONEquals(t, data, "126", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt8(0, false)
+	null := NewInt8(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestInt8Pointer(t *testing.T) {
 		t.Errorf("bad %s int8: %#v ≠ %d\n", "pointer", ptr, 126)
 	}
 
-	null := NewInt8(0, false)
+	null := NewInt8(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int8: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestInt8IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt8(0, false)
+	null := NewInt8(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt8(0, true)
+	zero := NewInt8(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestInt8SetValid(t *testing.T) {
-	change := NewInt8(0, false)
+	change := NewInt8(0, false, true)
 	assertNullInt8(t, change, "SetValid()")
 	change.SetValid(126)
 	assertInt8(t, change, "SetValid()")

--- a/int_test.go
+++ b/int_test.go
@@ -39,6 +39,9 @@ func TestUnmarshalInt(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullInt(t, null, "null json")
+	if !null.set {
+		t.Error("is not set, but should be")
+	}
 
 	var badType Int
 	err = json.Unmarshal(boolJSON, &badType)
@@ -82,7 +85,7 @@ func TestMarshalInt(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt(0, false)
+	null := NewInt(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -95,7 +98,7 @@ func TestMarshalIntText(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewInt(0, false)
+	null := NewInt(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -108,7 +111,7 @@ func TestIntPointer(t *testing.T) {
 		t.Errorf("bad %s int: %#v ≠ %d\n", "pointer", ptr, 12345)
 	}
 
-	null := NewInt(0, false)
+	null := NewInt(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s int: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -121,19 +124,19 @@ func TestIntIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewInt(0, false)
+	null := NewInt(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewInt(0, true)
+	zero := NewInt(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestIntSetValid(t *testing.T) {
-	change := NewInt(0, false)
+	change := NewInt(0, false, true)
 	assertNullInt(t, change, "SetValid()")
 	change.SetValid(12345)
 	assertInt(t, change, "SetValid()")

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,5 @@
+package null
+
+type Nullable interface {
+	IsSet() bool
+}

--- a/json.go
+++ b/json.go
@@ -15,28 +15,34 @@ import (
 type JSON struct {
 	JSON  []byte
 	Valid bool
+	set   bool
 }
 
 // NewJSON creates a new JSON
-func NewJSON(b []byte, valid bool) JSON {
+func NewJSON(b []byte, valid, set bool) JSON {
 	return JSON{
 		JSON:  b,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // JSONFrom creates a new JSON that will be invalid if nil.
 func JSONFrom(b []byte) JSON {
-	return NewJSON(b, b != nil)
+	return NewJSON(b, b != nil, true)
 }
 
 // JSONFromPtr creates a new JSON that will be invalid if nil.
 func JSONFromPtr(b *[]byte) JSON {
 	if b == nil {
-		return NewJSON(nil, false)
+		return NewJSON(nil, false, true)
 	}
-	n := NewJSON(*b, true)
+	n := NewJSON(*b, true, true)
 	return n
+}
+
+func (j JSON) IsSet() bool {
+	return j.set
 }
 
 // Unmarshal will unmarshal your JSON stored in
@@ -60,6 +66,7 @@ func (j JSON) Unmarshal(dest interface{}) error {
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *JSON) UnmarshalJSON(data []byte) error {
+	j.set = true
 	if data == nil {
 		return fmt.Errorf("json: cannot unmarshal nil into Go value of type null.JSON")
 	}

--- a/json_test.go
+++ b/json_test.go
@@ -126,6 +126,9 @@ func TestUnmarshalJSON(t *testing.T) {
 	if !bytes.Equal(null.JSON, nil) {
 		t.Errorf("Expected JSON to be []byte nil, but was not: %#v %#v", null.JSON, []byte(nil))
 	}
+	if !null.set {
+		t.Error("should be set")
+	}
 }
 
 func TestTextUnmarshalJSON(t *testing.T) {
@@ -147,7 +150,7 @@ func TestMarshalJSON(t *testing.T) {
 	assertJSONEquals(t, data, `"hello"`, "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewJSON(nil, false)
+	null := NewJSON(nil, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -160,7 +163,7 @@ func TestMarshalJSONText(t *testing.T) {
 	assertJSONEquals(t, data, `"hello"`, "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewJSON(nil, false)
+	null := NewJSON(nil, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -173,7 +176,7 @@ func TestJSONPointer(t *testing.T) {
 		t.Errorf("bad %s []byte: %#v ≠ %s\n", "pointer", ptr, `"hello"`)
 	}
 
-	null := NewJSON(nil, false)
+	null := NewJSON(nil, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s []byte: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -186,19 +189,19 @@ func TestJSONIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewJSON(nil, false)
+	null := NewJSON(nil, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewJSON(nil, true)
+	zero := NewJSON(nil, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestJSONSetValid(t *testing.T) {
-	change := NewJSON(nil, false)
+	change := NewJSON(nil, false, true)
 	assertNullJSON(t, change, "SetValid()")
 	change.SetValid([]byte(`"hello"`))
 	assertJSON(t, change, "SetValid()")

--- a/string.go
+++ b/string.go
@@ -13,31 +13,38 @@ import (
 type String struct {
 	String string
 	Valid  bool
+	set    bool
 }
 
 // StringFrom creates a new String that will never be blank.
 func StringFrom(s string) String {
-	return NewString(s, true)
+	return NewString(s, true, true)
 }
 
 // StringFromPtr creates a new String that be null if s is nil.
 func StringFromPtr(s *string) String {
 	if s == nil {
-		return NewString("", false)
+		return NewString("", false, true)
 	}
-	return NewString(*s, true)
+	return NewString(*s, true, true)
 }
 
 // NewString creates a new String
-func NewString(s string, valid bool) String {
+func NewString(s string, valid, set bool) String {
 	return String{
 		String: s,
 		Valid:  valid,
+		set:    set,
 	}
+}
+
+func (s String) IsSet() bool {
+	return s.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (s *String) UnmarshalJSON(data []byte) error {
+	s.set = true
 	if bytes.Equal(data, NullBytes) {
 		s.String = ""
 		s.Valid = false

--- a/string_test.go
+++ b/string_test.go
@@ -54,6 +54,9 @@ func TestUnmarshalString(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullStr(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType String
 	err = json.Unmarshal(boolJSON, &badType)
@@ -124,7 +127,7 @@ func TestStringPointer(t *testing.T) {
 		t.Errorf("bad %s string: %#v ≠ %s\n", "pointer", ptr, "test")
 	}
 
-	null := NewString("", false)
+	null := NewString("", false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s string: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -142,7 +145,7 @@ func TestStringIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	empty := NewString("", true)
+	empty := NewString("", true, true)
 	if empty.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
@@ -154,7 +157,7 @@ func TestStringIsZero(t *testing.T) {
 }
 
 func TestStringSetValid(t *testing.T) {
-	change := NewString("", false)
+	change := NewString("", false, true)
 	assertNullStr(t, change, "SetValid()")
 	change.SetValid("test")
 	assertStr(t, change, "SetValid()")

--- a/time.go
+++ b/time.go
@@ -13,27 +13,33 @@ import (
 type Time struct {
 	Time  time.Time
 	Valid bool
+	set   bool
 }
 
 // NewTime creates a new Time.
-func NewTime(t time.Time, valid bool) Time {
+func NewTime(t time.Time, valid, set bool) Time {
 	return Time{
 		Time:  t,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // TimeFrom creates a new Time that will always be valid.
 func TimeFrom(t time.Time) Time {
-	return NewTime(t, true)
+	return NewTime(t, true, true)
 }
 
 // TimeFromPtr creates a new Time that will be null if t is nil.
 func TimeFromPtr(t *time.Time) Time {
 	if t == nil {
-		return NewTime(time.Time{}, false)
+		return NewTime(time.Time{}, false, true)
 	}
-	return NewTime(*t, true)
+	return NewTime(*t, true, true)
+}
+
+func (t Time) IsSet() bool {
+	return t.set
 }
 
 // MarshalJSON implements json.Marshaler.
@@ -46,6 +52,7 @@ func (t Time) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (t *Time) UnmarshalJSON(data []byte) error {
+	t.set = true
 	if bytes.Equal(data, NullBytes) {
 		t.Valid = false
 		t.Time = time.Time{}

--- a/time_test.go
+++ b/time_test.go
@@ -24,6 +24,9 @@ func TestUnmarshalTimeJSON(t *testing.T) {
 	err = json.Unmarshal(nullTimeJSON, &null)
 	maybePanic(err)
 	assertNullTime(t, null, "null time json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var invalid Time
 	err = invalid.UnmarshalJSON(invalidJSON)
@@ -93,7 +96,7 @@ func TestTimeFromPtr(t *testing.T) {
 
 func TestTimeSetValid(t *testing.T) {
 	var ti time.Time
-	change := NewTime(ti, false)
+	change := NewTime(ti, false, true)
 	assertNullTime(t, change, "SetValid()")
 	change.SetValid(timeValue)
 	assertTime(t, change, "SetValid()")
@@ -107,7 +110,7 @@ func TestTimePointer(t *testing.T) {
 	}
 
 	var nt time.Time
-	null := NewTime(nt, false)
+	null := NewTime(nt, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s time: %#v ≠ %s\n", "nil pointer", ptr, "nil")

--- a/uint.go
+++ b/uint.go
@@ -13,31 +13,38 @@ import (
 type Uint struct {
 	Uint  uint
 	Valid bool
+	set   bool
 }
 
 // NewUint creates a new Uint
-func NewUint(i uint, valid bool) Uint {
+func NewUint(i uint, valid, set bool) Uint {
 	return Uint{
 		Uint:  i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // UintFrom creates a new Uint that will always be valid.
 func UintFrom(i uint) Uint {
-	return NewUint(i, true)
+	return NewUint(i, true, true)
 }
 
 // UintFromPtr creates a new Uint that be null if i is nil.
 func UintFromPtr(i *uint) Uint {
 	if i == nil {
-		return NewUint(0, false)
+		return NewUint(0, false, true)
 	}
-	return NewUint(*i, true)
+	return NewUint(*i, true, true)
+}
+
+func (u Uint) IsSet() bool {
+	return u.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint) UnmarshalJSON(data []byte) error {
+	u.set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint = 0

--- a/uint16.go
+++ b/uint16.go
@@ -15,31 +15,38 @@ import (
 type Uint16 struct {
 	Uint16 uint16
 	Valid  bool
+	set    bool
 }
 
 // NewUint16 creates a new Uint16
-func NewUint16(i uint16, valid bool) Uint16 {
+func NewUint16(i uint16, valid, set bool) Uint16 {
 	return Uint16{
 		Uint16: i,
 		Valid:  valid,
+		set:    set,
 	}
 }
 
 // Uint16From creates a new Uint16 that will always be valid.
 func Uint16From(i uint16) Uint16 {
-	return NewUint16(i, true)
+	return NewUint16(i, true, true)
 }
 
 // Uint16FromPtr creates a new Uint16 that be null if i is nil.
 func Uint16FromPtr(i *uint16) Uint16 {
 	if i == nil {
-		return NewUint16(0, false)
+		return NewUint16(0, false, true)
 	}
-	return NewUint16(*i, true)
+	return NewUint16(*i, true, true)
+}
+
+func (u Uint16) IsSet() bool {
+	return u.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint16) UnmarshalJSON(data []byte) error {
+	u.set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint16 = 0

--- a/uint16_test.go
+++ b/uint16_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalUint16(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint16(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Uint16
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalUint16(t *testing.T) {
 	assertJSONEquals(t, data, "65534", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint16(0, false)
+	null := NewUint16(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalUint16Text(t *testing.T) {
 	assertJSONEquals(t, data, "65534", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint16(0, false)
+	null := NewUint16(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestUint16Pointer(t *testing.T) {
 		t.Errorf("bad %s uint16: %#v ≠ %d\n", "pointer", ptr, 65534)
 	}
 
-	null := NewUint16(0, false)
+	null := NewUint16(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint16: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestUint16IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint16(0, false)
+	null := NewUint16(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint16(0, true)
+	zero := NewUint16(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint16SetValid(t *testing.T) {
-	change := NewUint16(0, false)
+	change := NewUint16(0, false, true)
 	assertNullUint16(t, change, "SetValid()")
 	change.SetValid(65534)
 	assertUint16(t, change, "SetValid()")

--- a/uint32.go
+++ b/uint32.go
@@ -15,31 +15,38 @@ import (
 type Uint32 struct {
 	Uint32 uint32
 	Valid  bool
+	set    bool
 }
 
 // NewUint32 creates a new Uint32
-func NewUint32(i uint32, valid bool) Uint32 {
+func NewUint32(i uint32, valid, set bool) Uint32 {
 	return Uint32{
 		Uint32: i,
 		Valid:  valid,
+		set:    set,
 	}
 }
 
 // Uint32From creates a new Uint32 that will always be valid.
 func Uint32From(i uint32) Uint32 {
-	return NewUint32(i, true)
+	return NewUint32(i, true, true)
 }
 
 // Uint32FromPtr creates a new Uint32 that be null if i is nil.
 func Uint32FromPtr(i *uint32) Uint32 {
 	if i == nil {
-		return NewUint32(0, false)
+		return NewUint32(0, false, true)
 	}
-	return NewUint32(*i, true)
+	return NewUint32(*i, true, true)
+}
+
+func (u Uint32) IsSet() bool {
+	return u.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint32) UnmarshalJSON(data []byte) error {
+	u.set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint32 = 0

--- a/uint32_test.go
+++ b/uint32_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalUint32(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint32(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Uint32
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalUint32(t *testing.T) {
 	assertJSONEquals(t, data, "4294967294", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint32(0, false)
+	null := NewUint32(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalUint32Text(t *testing.T) {
 	assertJSONEquals(t, data, "4294967294", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint32(0, false)
+	null := NewUint32(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestUint32Pointer(t *testing.T) {
 		t.Errorf("bad %s uint32: %#v ≠ %d\n", "pointer", ptr, 4294967294)
 	}
 
-	null := NewUint32(0, false)
+	null := NewUint32(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint32: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestUint32IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint32(0, false)
+	null := NewUint32(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint32(0, true)
+	zero := NewUint32(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint32SetValid(t *testing.T) {
-	change := NewUint32(0, false)
+	change := NewUint32(0, false, true)
 	assertNullUint32(t, change, "SetValid()")
 	change.SetValid(4294967294)
 	assertUint32(t, change, "SetValid()")

--- a/uint64.go
+++ b/uint64.go
@@ -13,31 +13,38 @@ import (
 type Uint64 struct {
 	Uint64 uint64
 	Valid  bool
+	set    bool
 }
 
 // NewUint64 creates a new Uint64
-func NewUint64(i uint64, valid bool) Uint64 {
+func NewUint64(i uint64, valid, set bool) Uint64 {
 	return Uint64{
 		Uint64: i,
 		Valid:  valid,
+		set:    set,
 	}
 }
 
 // Uint64From creates a new Uint64 that will always be valid.
 func Uint64From(i uint64) Uint64 {
-	return NewUint64(i, true)
+	return NewUint64(i, true, true)
 }
 
 // Uint64FromPtr creates a new Uint64 that be null if i is nil.
 func Uint64FromPtr(i *uint64) Uint64 {
 	if i == nil {
-		return NewUint64(0, false)
+		return NewUint64(0, false, true)
 	}
-	return NewUint64(*i, true)
+	return NewUint64(*i, true, true)
+}
+
+func (u Uint64) IsSet() bool {
+	return u.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint64) UnmarshalJSON(data []byte) error {
+	u.set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Uint64 = 0
 		u.Valid = false

--- a/uint64_test.go
+++ b/uint64_test.go
@@ -39,6 +39,9 @@ func TestUnmarshalUint64(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint64(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Uint64
 	err = json.Unmarshal(boolJSON, &badType)
@@ -82,7 +85,7 @@ func TestMarshalUint64(t *testing.T) {
 	assertJSONEquals(t, data, "18446744073709551614", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint64(0, false)
+	null := NewUint64(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -95,7 +98,7 @@ func TestMarshalUint64Text(t *testing.T) {
 	assertJSONEquals(t, data, "18446744073709551614", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint64(0, false)
+	null := NewUint64(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -108,7 +111,7 @@ func TestUint64Pointer(t *testing.T) {
 		t.Errorf("bad %s uint64: %#v ≠ %d\n", "pointer", ptr, uint64(18446744073709551614))
 	}
 
-	null := NewUint64(0, false)
+	null := NewUint64(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint64: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -121,19 +124,19 @@ func TestUint64IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint64(0, false)
+	null := NewUint64(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint64(0, true)
+	zero := NewUint64(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint64SetValid(t *testing.T) {
-	change := NewUint64(0, false)
+	change := NewUint64(0, false, true)
 	assertNullUint64(t, change, "SetValid()")
 	change.SetValid(18446744073709551614)
 	assertUint64(t, change, "SetValid()")

--- a/uint8.go
+++ b/uint8.go
@@ -15,31 +15,38 @@ import (
 type Uint8 struct {
 	Uint8 uint8
 	Valid bool
+	set   bool
 }
 
 // NewUint8 creates a new Uint8
-func NewUint8(i uint8, valid bool) Uint8 {
+func NewUint8(i uint8, valid, set bool) Uint8 {
 	return Uint8{
 		Uint8: i,
 		Valid: valid,
+		set:   set,
 	}
 }
 
 // Uint8From creates a new Uint8 that will always be valid.
 func Uint8From(i uint8) Uint8 {
-	return NewUint8(i, true)
+	return NewUint8(i, true, true)
 }
 
 // Uint8FromPtr creates a new Uint8 that be null if i is nil.
 func Uint8FromPtr(i *uint8) Uint8 {
 	if i == nil {
-		return NewUint8(0, false)
+		return NewUint8(0, false, true)
 	}
-	return NewUint8(*i, true)
+	return NewUint8(*i, true, true)
+}
+
+func (u Uint8) IsSet() bool {
+	return u.set
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (u *Uint8) UnmarshalJSON(data []byte) error {
+	u.set = true
 	if bytes.Equal(data, NullBytes) {
 		u.Valid = false
 		u.Uint8 = 0

--- a/uint8_test.go
+++ b/uint8_test.go
@@ -41,6 +41,9 @@ func TestUnmarshalUint8(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint8(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Uint8
 	err = json.Unmarshal(boolJSON, &badType)
@@ -100,7 +103,7 @@ func TestMarshalUint8(t *testing.T) {
 	assertJSONEquals(t, data, "254", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint8(0, false)
+	null := NewUint8(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -113,7 +116,7 @@ func TestMarshalUint8Text(t *testing.T) {
 	assertJSONEquals(t, data, "254", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint8(0, false)
+	null := NewUint8(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -126,7 +129,7 @@ func TestUint8Pointer(t *testing.T) {
 		t.Errorf("bad %s uint8: %#v ≠ %d\n", "pointer", ptr, 254)
 	}
 
-	null := NewUint8(0, false)
+	null := NewUint8(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint8: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -139,19 +142,19 @@ func TestUint8IsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint8(0, false)
+	null := NewUint8(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint8(0, true)
+	zero := NewUint8(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUint8SetValid(t *testing.T) {
-	change := NewUint8(0, false)
+	change := NewUint8(0, false, true)
 	assertNullUint8(t, change, "SetValid()")
 	change.SetValid(254)
 	assertUint8(t, change, "SetValid()")

--- a/uint_test.go
+++ b/uint_test.go
@@ -39,6 +39,9 @@ func TestUnmarshalUint(t *testing.T) {
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)
 	assertNullUint(t, null, "null json")
+	if !null.set {
+		t.Error("should be set")
+	}
 
 	var badType Uint
 	err = json.Unmarshal(boolJSON, &badType)
@@ -82,7 +85,7 @@ func TestMarshalUint(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint(0, false)
+	null := NewUint(0, false, true)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -95,7 +98,7 @@ func TestMarshalUintText(t *testing.T) {
 	assertJSONEquals(t, data, "12345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewUint(0, false)
+	null := NewUint(0, false, true)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -108,7 +111,7 @@ func TestUintPointer(t *testing.T) {
 		t.Errorf("bad %s uint: %#v ≠ %d\n", "pointer", ptr, 12345)
 	}
 
-	null := NewUint(0, false)
+	null := NewUint(0, false, true)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s uint: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -121,19 +124,19 @@ func TestUintIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewUint(0, false)
+	null := NewUint(0, false, true)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewUint(0, true)
+	zero := NewUint(0, true, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestUintSetValid(t *testing.T) {
-	change := NewUint(0, false)
+	change := NewUint(0, false, true)
 	assertNullUint(t, change, "SetValid()")
 	change.SetValid(12345)
 	assertUint(t, change, "SetValid()")


### PR DESCRIPTION
inspired by https://www.calhoun.io/how-to-determine-if-a-json-key-has-been-set-to-null-or-not-provided/

This allows the user to easily determine the difference between a json key not being supplied, and it being set to null. It's critical when supporting HTTP PATCH as well as other use cases when we need to know whether the key was sent at all.